### PR TITLE
Do not skip hipcc compilation when dynamic library file is not found

### DIFF
--- a/ff/baby_bear.hpp
+++ b/ff/baby_bear.hpp
@@ -2,12 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __SPPARK_FF_BABY_BEAR_HPP__
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && \
+    !defined(__SPPARK_FF_BABY_BEAR_HPP__)
 #define __SPPARK_FF_BABY_BEAR_HPP__
 
-#ifdef __CUDACC__   // CUDA device-side field types
 # include <cassert>
-# include "mont32_t.cuh"
+# ifdef __CUDACC__  // CUDA device-side field types
+#  include "mont32_t.cuh"
+# else
+#  include "mont32_t.hip"
+# endif
 # define inline __device__ __forceinline__
 
 using bb31_base = mont32_t<31, 0x78000001, 0x77ffffff, 0x45dddde3, 0x0ffffffe>;
@@ -705,5 +709,4 @@ public:
 typedef bb31_t fr_t;
 typedef bb31_4_t fr4_t;
 
-#endif
 #endif

--- a/ff/baby_bear.hpp
+++ b/ff/baby_bear.hpp
@@ -83,9 +83,9 @@ public:
     inline bb31_4_t()           {}
     inline bb31_4_t(bb31_t a)   { c[0] = a; u[1] = u[2] = u[3] = 0; }
     // this is used in constant declaration, e.g. as bb31_4_t{1, 2, 3, 4}
-    __host__ __device__ __forceinline__ bb31_4_t(int a)
+    __host__ inline bb31_4_t(int a)
     {   c[0] = bb31_t{a}; u[1] = u[2] = u[3] = 0;   }
-    __host__ __device__ __forceinline__ bb31_4_t(int d, int f, int g, int h)
+    __host__ inline bb31_4_t(int d, int f, int g, int h)
     {   c[0] = bb31_t{d}; c[1] = bb31_t{f}; c[2] = bb31_t{g}; c[3] = bb31_t{h};   }
 
     static inline bb31_4_t csel(const bb31_4_t& a, const bb31_4_t& b, int sel_a)
@@ -631,9 +631,9 @@ public:
     static inline const bb31_4_t one()
     {   return bb31_4_t{1};   }
     inline bool is_one() const
-    {   return c[0].is_one() & u[1]==0 & u[2]==0 & u[3]==0;   }
+    {   return c[0].is_one() & (u[1]==0) & (u[2]==0) & (u[3]==0);   }
     inline bool is_zero() const
-    {   return u[0]==0 & u[1]==0 & u[2]==0 & u[3]==0;   }
+    {   return (u[0]==0) & (u[1]==0) & (u[2]==0) & (u[3]==0);   }
 
     // raise to a variable power, variable in respect to threadIdx,
     // but mind the ^ operator's precedence!
@@ -689,9 +689,9 @@ public:
 
 public:
     friend inline bool operator==(const bb31_4_t& a, const bb31_4_t& b)
-    {   return a.u[0]==b.u[0] & a.u[1]==b.u[1] & a.u[2]==b.u[2] & a.u[3]==b.u[3];   }
+    {   return (a.u[0]==b.u[0]) & (a.u[1]==b.u[1]) & (a.u[2]==b.u[2]) & (a.u[3]==b.u[3]);   }
     friend inline bool operator!=(const bb31_4_t& a, const bb31_4_t& b)
-    {   return a.u[0]!=b.u[0] | a.u[1]!=b.u[1] | a.u[2]!=b.u[2] | a.u[3]!=b.u[3];   }
+    {   return (a.u[0]!=b.u[0]) | (a.u[1]!=b.u[1]) | (a.u[2]!=b.u[2]) | (a.u[3]!=b.u[3]);   }
 
 # if defined(_GLIBCXX_IOSTREAM) || defined(_IOSTREAM_) // non-standard
     friend std::ostream& operator<<(std::ostream& os, const bb31_4_t& a)

--- a/ff/bls12-381.hpp
+++ b/ff/bls12-381.hpp
@@ -6,7 +6,7 @@
 #define __SPPARK_FF_BLS13_381_HPP__
 
 #include <cstdint>
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 
 namespace device {
 #define TO_CUDA_T(limb64) (uint32_t)(limb64), (uint32_t)(limb64>>32)
@@ -50,8 +50,13 @@ namespace device {
     };
     static __device__ __constant__ /*const*/ uint32_t BLS12_381_m0 = 0xffffffff;
 }
-# ifdef __CUDA_ARCH__   // device-side field types
-# include "mont_t.cuh"
+# if defined(__CUDA_ARCH__) || defined(__HIPCC__)   // device-side field types
+#  if defined(__CUDA_ARCH__)
+#   include "mont_t.cuh"
+#  elif defined(__HIPCC__)
+#   include "mont_t.hip"
+typedef uint64_t vec256[4];
+#  endif
 typedef mont_t<381, device::BLS12_381_P, device::BLS12_381_M0,
                     device::BLS12_381_RR, device::BLS12_381_one,
                     device::BLS12_381_Px8> fp_mont;
@@ -67,11 +72,14 @@ struct fr_t : public fr_mont {
     using mem_t = fr_t;
     __device__ __forceinline__ fr_t() {}
     __device__ __forceinline__ fr_t(const fr_mont& a) : fr_mont(a) {}
+#  ifdef __HIPCC__
+    __host__   __forceinline__ fr_t(vec256 a)         : fr_mont(a) {}
+#  endif
 };
 # endif
 #endif
 
-#ifndef __CUDA_ARCH__   // host-side field types
+#if !defined(__CUDA_ARCH__) && !defined(__HIPCC__)  // host-side field types
 # include <blst_t.hpp>
 
 # if defined(__GNUC__) && !defined(__clang__)

--- a/ff/gl64_t.hip
+++ b/ff/gl64_t.hip
@@ -1,0 +1,568 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(__HIPCC__) && !defined(__SPPARK_FF_GL64_T_HIP__)
+#define __SPPARK_FF_GL64_T_HIP__
+
+# include <cstdint>
+
+# if defined(__GFX10__) || defined(__GFX11__) //? || defined(__GFX12__)
+#  define v_addc_co_u32 "v_add_co_ci_u32 "
+#  define v_subb_co_u32 "v_sub_co_ci_u32 "
+# elif defined(__GFX9__)
+#  define v_addc_co_u32 "v_addc_co_u32 "
+#  define v_subb_co_u32 "v_subb_co_u32 "
+# elif !defined(__HIP_DEVICE_COMPILE__)
+#  define v_addc_co_u32 "v_dummy "
+#  define v_subb_co_u32 "v_dummy "
+# else
+#  error "unsupported GFX architecture"
+# endif
+
+# define __GL64_T_STR(x) #x
+# define __GL64_T_XSTR(x) __GL64_T_STR(x)
+# define S_OP(op) "s_" #op "_b" __GL64_T_XSTR(__AMDGCN_WAVEFRONT_SIZE) " "
+
+# define inline __device__ __forceinline__
+
+class gl64_t {
+private:
+    union {
+        uint64_t ul;
+        uint32_t u[2];
+    };
+#if __AMDGCN_WAVEFRONT_SIZE == 64
+    using cond_t = uint64_t;
+#else
+    using cond_t = uint32_t;
+#endif
+
+public:
+    using mem_t = gl64_t;
+    static const uint32_t degree = 1;
+    static const unsigned nbits = 64;
+    static const uint64_t MOD = 0xffffffff00000001U;
+    static constexpr size_t __device__ bit_length()     { return 64; }
+
+    inline uint32_t& operator[](size_t i)               { return u[i]; }
+    inline const uint32_t& operator[](size_t i) const   { return u[i]; }
+    inline size_t len() const                           { return 2;    }
+
+    inline gl64_t()                                     {}
+    inline gl64_t(int a)                    : ul(a)     {}
+#ifdef __HIP_DEVICE_COMPILE__
+    inline gl64_t(uint64_t a)               : ul(a)     { to(); }
+#else
+    __host__ constexpr gl64_t(uint64_t a)   : ul(a)     {}
+#endif
+    inline gl64_t(const uint64_t *p)        : ul(*p)    { to(); }
+
+    inline operator uint64_t() const
+    {   auto ret = *this; ret.from(); return ret.ul;   }
+    inline void store(uint64_t *p) const
+    {   *p = *this;   }
+
+    inline gl64_t& operator+=(const gl64_t& b)
+    {
+        cond_t carry, borrow;
+        uint32_t lo, hi;
+
+        asm("v_add_co_u32   %0, %1, %0, %2"     : "+v"(u[0]), "=s"(carry)
+                                                : "v"(b[0]));
+        asm( v_addc_co_u32 "%0, %1, %0, %2, %1" : "+v"(u[1]), "+s"(carry)
+                                                : "v"(b[1]));
+        asm("v_sub_co_u32   %0, %1, %2, 1"      : "=v"(lo), "=s"(borrow)
+                                                : "v"(u[0]));
+        asm( v_subb_co_u32 "%0, %1, %2, -1, %1" : "=v"(hi), "+s"(borrow)
+                                                : "v"(u[1]));
+#if defined(__GFX11__)
+        asm(S_OP(or_not1)  "%0, %0, %1"         : "+s"(carry)
+                                                : "s"(borrow));
+#else
+        asm(S_OP(orn2)     "%0, %0, %1"         : "+s"(carry)
+                                                : "s"(borrow));
+#endif
+        asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(u[0])
+                                                : "v"(lo), "s"(carry));
+        asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(u[1])
+                                                : "v"(hi), "s"(carry));
+        return *this;
+    }
+    friend inline gl64_t operator+(gl64_t a, const gl64_t& b)
+    {   return a += b;   }
+
+    inline gl64_t& operator-=(const gl64_t& b)
+    {
+        cond_t borrow, carry;
+        uint32_t lo, hi;
+
+        asm("v_sub_co_u32   %0, %1, %0, %2"     : "+v"(u[0]), "=s"(borrow)
+                                                : "v"(b[0]));
+        asm( v_subb_co_u32 "%0, %1, %0, %2, %1" : "+v"(u[1]), "+s"(borrow)
+                                                : "v"(b[1]));
+        asm("v_add_co_u32   %0, %1, %2, 1"      : "=v"(lo), "=s"(carry)
+                                                : "v"(u[0]));
+        asm( v_addc_co_u32 "%0, %1, %2, -1, %1" : "=v"(hi), "+s"(carry)
+                                                : "v"(u[1]));
+        asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(u[0])
+                                                : "v"(lo), "s"(borrow));
+        asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(u[1])
+                                                : "v"(hi), "s"(borrow));
+        return *this;
+    }
+    friend inline gl64_t operator-(gl64_t a, const gl64_t& b)
+    {   return a -= b;   }
+
+    inline gl64_t& operator<<=(int l)
+    {
+        uint32_t carry;
+        cond_t borrow;
+
+        while (l--) {
+            carry = (int)u[1] >> 31;
+            asm("v_lshlrev_b64  %0, 1, %0"          : "+v"(ul));
+            asm("v_add_co_u32   %0, %1, %0, %2"     : "+v"(u[0]), "=s"(borrow)
+                                                    : "v"(carry));
+            asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(u[1]), "+s"(borrow));
+        }
+
+        return *this;
+    }
+    friend inline gl64_t operator<<(gl64_t a, int l)
+    {   return a <<= l;   }
+
+    inline gl64_t& operator>>=(int r)
+    {
+        uint32_t odd;
+        cond_t carry;
+
+        while (r--) {
+            odd = u[0]&1;
+            asm("v_add_co_u32   %0, %1, %0, %2"     : "+v"(u[0]), "=s"(carry)
+                                                    : "v"(odd));
+            asm( v_addc_co_u32 "%0, %1, %0, %2, %1" : "+v"(u[1]), "+s"(carry)
+                                                    : "v"(-odd));
+            asm( v_addc_co_u32 "%0, %1, 0, 0, %1"   : "=v"(odd), "+s"(carry));
+            asm("v_lshrrev_b64  %0, 1, %0"          : "+v"(ul));
+            u[1] |= odd<<31;
+        }
+
+        return *this;
+    }
+    friend inline gl64_t operator>>(gl64_t a, int r)
+    {   return a >>= r;   }
+
+private:
+    inline gl64_t& cneg(cond_t cond)
+    {
+        cond_t borrow, nzero;
+        uint32_t lo, hi;
+
+        asm("v_cmp_ne_u64   %0, %1, 0"          : "=s"(nzero)
+                                                : "v"(ul));
+        asm("v_sub_co_u32   %0, %1, 1, %2"      : "=v"(lo), "=s"(borrow)
+                                                : "v"(u[0]));
+        asm(S_OP(and)      "%0, %0, %1"         : "+s"(cond)
+                                                : "s"(nzero));
+        asm( v_subb_co_u32 "%0, %1, -1, %2, %1" : "=v"(hi), "+s"(borrow)
+                                                : "v"(u[1]));
+        asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(u[0])
+                                                : "v"(lo), "s"(cond));
+        asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(u[1])
+                                                : "v"(hi), "s"(cond));
+        return *this;
+    }
+
+public:
+    inline gl64_t& cneg(int flag)
+    {
+        cond_t cond;
+        asm("v_cmp_ne_u32 %0, %1, 0" : "=s"(cond) : "v"(flag));
+        return cneg(cond);
+    }
+    static inline gl64_t cneg(gl64_t a, int flag)
+    {   return a.cneg(flag);   }
+    inline gl64_t operator-() const
+    {   gl64_t ret = *this; return ret.cneg((cond_t)0-1);   }
+
+    static inline const gl64_t one()
+    {   gl64_t ret; ret.ul = 1; return ret;   }
+
+    inline bool is_zero() const { return ul == 0;   }
+    inline bool is_one()  const { return ul == 1;   }
+
+    inline void zero()
+    {   ul = 0;   }
+
+    friend inline gl64_t czero(const gl64_t& a, int set_z)
+    {
+        gl64_t ret;
+        cond_t cond;
+
+        asm("v_cmp_ne_u32  %0, %1, 0"       : "=s"(cond)
+                                            : "v"(set_z));
+        asm("v_cndmask_b32 %0, %1, 0, %2"   : "=v"(ret[0])
+                                            : "v"(a[0]), "s"(cond));
+        asm("v_cndmask_b32 %0, %1, 0, %2"   : "=v"(ret[1])
+                                            : "v"(a[1]), "s"(cond));
+        return ret;
+    }
+
+    static inline gl64_t csel(const gl64_t& a, const gl64_t& b, int sel_a)
+    {
+        gl64_t ret;
+        cond_t cond;
+
+        asm("v_cmp_ne_u32  %0, %1, 0"       : "=s"(cond)
+                                            : "v"(sel_a));
+        asm("v_cndmask_b32 %0, %1, %2, %3"  : "=v"(ret[0])
+                                            : "v"(b[0]), "v"(a[0]), "s"(cond));
+        asm("v_cndmask_b32 %0, %1, %2, %3"  : "=v"(ret[1])
+                                            : "v"(b[1]), "v"(a[1]), "s"(cond));
+        return ret;
+    }
+
+private:
+    inline void mul(uint32_t b)
+    {
+        cond_t carry;
+        uint32_t hi;
+        union { unsigned __int128 ull; uint64_t ul; uint32_t u[3]; } temp;
+
+        temp.ull = ul * (unsigned __int128)b;
+
+        asm("v_mad_u64_u32  %0, %1, %2, -1, %3" : "=v"(ul), "=s"(carry)
+                                                : "v"(temp.u[2]), "v"(temp.ul));
+        asm( v_addc_co_u32 "%0, %1, 0, 0, %1"   : "=v"(hi), "+s"(carry));
+
+        asm("v_sub_co_u32   %0, %1, %0, %2"     : "+v"(u[0]), "=s"(carry)
+                                                : "v"(hi));
+        asm( v_subb_co_u32 "%0, %1, %0, %2, %1" : "+v"(u[1]), "+s"(carry)
+                                                : "v"(-hi));
+    }
+
+public:
+    friend inline gl64_t operator*(gl64_t a, uint32_t b)
+    {   a.mul(b); a.to(); return a;   }
+    inline gl64_t& operator*=(uint32_t a)
+    {   mul(a);   to();   return *this;   }
+
+private:
+    using wide_t = union { unsigned __int128 ull; uint64_t ul[2]; uint32_t u[4]; };
+
+    inline void mul(const gl64_t& b)
+    {
+        wide_t temp;
+        temp.ull = (unsigned __int128)ul * b.ul;
+        reduce(temp);
+    }
+
+    inline void reduce(wide_t &w)
+    {
+        cond_t carry, borrow;
+
+        asm("v_mad_u64_u32  %0, %1, %2, -1, %0" : "+v"(w.ul[0]), "=s"(carry)
+                                                : "v"(w.u[2]));
+        asm( v_addc_co_u32 "%0, %1, 0, 0, %1"   : "=v"(w.u[2]), "+s"(carry));
+
+        asm("v_sub_co_u32   %0, %1, %0, %2"     : "+v"(w.u[0]), "=s"(borrow)
+                                                : "v"(w.u[3]));
+        asm( v_subb_co_u32 "%0, %1, %0, 0, %1"  : "+v"(w.u[1]), "+s"(borrow));
+        asm( v_subb_co_u32 "%0, %1, %0, 0, %1"  : "+v"(w.u[2]), "+s"(borrow));
+
+        asm("v_sub_co_u32   %0, %1, %2, %3"     : "=v"(u[0]), "=s"(carry)
+                                                : "v"(w.u[0]), "v"(w.u[2]));
+        asm( v_subb_co_u32 "%0, %1, %2, %3, %1" : "=v"(u[1]), "+s"(carry)
+                                                : "v"(w.u[1]), "v"(-(int)w.u[2]>>1));
+    }
+
+public:
+    friend inline gl64_t operator*(gl64_t a, const gl64_t& b)
+    {   a.mul(b); a.to(); return a;   }
+    inline gl64_t& operator*=(const gl64_t& a)
+    {   mul(a);   to();   return *this;   }
+
+    // raise to a variable power, variable in respect to threadIdx,
+    // but mind the ^ operator's precedence!
+    inline gl64_t& operator^=(uint32_t p)
+    {
+        gl64_t sqr = *this;
+        *this = csel(*this, one(), p&1);
+
+        #pragma unroll 1
+        while (p >>= 1) {
+            sqr.mul(sqr);
+            if (p&1)
+                mul(sqr);
+        }
+        to();
+
+        return *this;
+    }
+    friend inline gl64_t operator^(gl64_t a, uint32_t p)
+    {   return a ^= p;   }
+    inline gl64_t operator()(uint32_t p)
+    {   return *this^p;   }
+
+    // raise to a constant power, e.g. x^7, to be unrolled at compile time
+    inline gl64_t& operator^=(int p)
+    {
+        assert(p >= 2);
+
+        gl64_t sqr = *this;
+        if ((p&1) == 0) {
+            do {
+                sqr.mul(sqr);
+                p >>= 1;
+            } while ((p&1) == 0);
+            *this = sqr;
+        }
+        for (p >>= 1; p; p >>= 1) {
+            sqr.mul(sqr);
+            if (p&1)
+                mul(sqr);
+        }
+        to();
+
+        return *this;
+    }
+    friend inline gl64_t operator^(gl64_t a, int p)
+    {   return a ^= p;   }
+    inline gl64_t operator()(int p)
+    {   return *this^p;   }
+    friend inline gl64_t sqr(gl64_t a)
+    {   return a.sqr();   }
+    inline gl64_t& sqr()
+    {   mul(*this); to(); return *this;   }
+
+private:
+    inline void final_sub()
+    {
+        uint32_t lo, hi;
+        cond_t borrow;
+
+        asm("v_sub_co_u32   %0, %1, %2, 1"      : "=v"(lo), "=s"(borrow)
+                                                : "v"(u[0]));
+        asm( v_subb_co_u32 "%0, %1, %2, -1, %1" : "=v"(hi), "+s"(borrow)
+                                                : "v"(u[1]));
+        asm("v_cndmask_b32  %0, %1, %0, %2"     : "+v"(u[0])
+                                                : "v"(lo), "s"(borrow));
+        asm("v_cndmask_b32  %0, %1, %0, %2"     : "+v"(u[1])
+                                                : "v"(hi), "s"(borrow));
+    }
+
+public:
+    inline void to()    { final_sub(); }
+    inline void from()  {}
+
+    template<size_t T>
+    static inline gl64_t dot_product(const gl64_t a[T], const uint8_t b[T])
+    {
+        uint64_t lo_acc, hi_acc;
+        cond_t lo_c, hi_c;
+
+        uint32_t bi = b[0];
+        asm("v_mad_u64_u32 %0, %1, %2, %3, 0"   : "=v"(lo_acc), "=s"(lo_c)
+                                                : "v"(a[0][0]), "v"(bi));
+        asm("v_mad_u64_u32 %0, %1, %2, %3, 0"   : "=v"(hi_acc), "=s"(hi_c)
+                                                : "v"(a[0][1]), "v"(bi));
+
+        for (uint32_t i = 1; i < T; i++) {
+            bi = b[i];
+            asm("v_mad_u64_u32 %0, %1, %2, %3, %0"  : "+v"(lo_acc), "=s"(lo_c)
+                                                    : "v"(a[i][0]), "v"(bi));
+            asm("v_mad_u64_u32 %0, %1, %2, %3, %0"  : "+v"(hi_acc), "=s"(hi_c)
+                                                    : "v"(a[i][1]), "v"(bi));
+        }
+
+        gl64_t ret;
+        uint32_t carry;
+
+        ret.ul = lo_acc;
+        asm("v_add_co_u32   %0, %1, %0, %2"     : "+v"(ret[1]), "=s"(lo_c)
+                                                : "v"((uint32_t)hi_acc));
+        asm( v_addc_co_u32 "%0, %1, %2, 0, %1"  : "=v"(carry),  "+s"(lo_c)
+                                                : "v"((uint32_t)(hi_acc>>32)));
+
+        asm("v_mad_u64_u32  %0, %1, %2, -1, %0" : "+v"(ret.ul), "=s"(hi_c)
+                                                : "v"(carry));
+        asm( v_addc_co_u32 "%0, %1, 0, 0, %1"   : "=v"(carry), "+s"(hi_c));
+
+        asm("v_sub_co_u32   %0, %1, %0, %2"     : "+v"(ret[0]), "=s"(lo_c)
+                                                : "v"(carry));
+        asm( v_subb_co_u32 "%0, %1, %0, %2, %1" : "+v"(ret[1]), "+s"(lo_c)
+                                                : "v"(-carry));
+        ret.to();
+        return ret;
+    }
+
+    template<size_t T>
+    static inline gl64_t dot_product(const gl64_t a[T], const gl64_t b[T])
+    {
+        uint64_t lo_acc, mi_acc, hi_acc;
+        uint32_t lo_top, mi_top, hi_top;
+        cond_t lo_c, hi_c;
+
+        uint32_t a_lo = a[0][0], b_lo = b[0][0];
+        uint32_t a_hi = a[0][1], b_hi = b[0][1];
+
+        asm("v_mad_u64_u32  %0, %1, %2, %3, 0"  : "=v"(lo_acc), "=s"(lo_c)
+                                                : "v"(a_lo), "v"(b_lo));
+        lo_top = 0;
+
+        asm("v_mad_u64_u32  %0, %1, %2, %3, 0"  : "=v"(mi_acc), "=s"(hi_c)
+                                                : "v"(a_lo), "v"(b_hi));
+        asm("v_mad_u64_u32  %0, %1, %2, %3, %0" : "+v"(mi_acc), "=s"(lo_c)
+                                                : "v"(a_hi), "v"(b_lo));
+        asm( v_addc_co_u32 "%0, %1, 0, 0, %1"   : "=v"(mi_top), "+s"(lo_c));
+
+        asm("v_mad_u64_u32  %0, %1, %2, %3, 0"  : "=v"(hi_acc), "=s"(hi_c)
+                                                : "v"(a_hi), "v"(b_hi));
+        hi_top = 0;
+
+        for (uint32_t i = 1; i < T; i++) {
+            a_lo = a[i][0], b_lo = b[i][0];
+            a_hi = a[i][1], b_hi = b[i][1];
+
+            asm("v_mad_u64_u32  %0, %1, %2, %3, %0" : "+v"(lo_acc), "=s"(lo_c)
+                                                    : "v"(a_lo), "v"(b_lo));
+            asm("v_mad_u64_u32  %0, %1, %2, %3, %0" : "+v"(mi_acc), "=s"(hi_c)
+                                                    : "v"(a_lo), "v"(b_hi));
+            asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(lo_top), "+s"(lo_c));
+            asm("v_mad_u64_u32  %0, %1, %2, %3, %0" : "+v"(mi_acc), "=s"(lo_c)
+                                                    : "v"(a_hi), "v"(b_lo));
+            asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(mi_top), "+s"(hi_c));
+            asm("v_mad_u64_u32  %0, %1, %2, %3, %0" : "+v"(hi_acc), "=s"(hi_c)
+                                                    : "v"(a_hi), "v"(b_hi));
+            asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(mi_top), "+s"(lo_c));
+            asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(hi_top), "+s"(hi_c));
+        }
+
+        wide_t w;
+        w.u[0] = (uint32_t)lo_acc;
+
+        asm("v_add_co_u32   %0, %1, %2, %3"     : "=v"(w.u[1]), "=s"(lo_c)
+                                                : "v"((uint32_t)(lo_acc>>32)), "v"((uint32_t)mi_acc));
+        asm( v_addc_co_u32 "%0, %1, %2, %3, %1" : "=v"(w.u[2]), "+s"(lo_c)
+                                                : "v"((uint32_t)(mi_acc>>32)), "v"(lo_top));
+        asm( v_addc_co_u32 "%0, %1, %2, %3, %1" : "=v"(w.u[3]), "+s"(lo_c)
+                                                : "v"((uint32_t)(hi_acc>>32)), "v"(mi_top));
+        asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(hi_top),  "+s"(lo_c));
+
+        asm("v_add_co_u32   %0, %1, %0, %2"     : "+v"(w.u[2]), "=s"(hi_c)
+                                                : "v"((uint32_t)hi_acc));
+        asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(w.u[3]), "+s"(hi_c));
+        asm( v_addc_co_u32 "%0, %1, %0, 0, %1"  : "+v"(hi_top),  "+s"(hi_c));
+
+        // reduce modulo |(mod << 64) + (mod <<32)|
+        asm("v_sub_co_u32    %0, %1, %0, %2"    : "+v"(w.u[1]), "=s"(lo_c)
+                                                : "v"(hi_top));
+        asm( v_subb_co_u32 "%0, %1, %0, 0, %1"  : "+v"(w.u[2]), "+s"(lo_c));
+        asm( v_subb_co_u32 "%0, %1, %0, 0, %1"  : "+v"(w.u[3]), "+s"(lo_c));
+        asm( v_subb_co_u32 "%0, %1, %0, %0, %1" : "+v"(hi_top),  "+s"(lo_c));
+
+        // "add" |mod<<64| if reduction borrowed
+        w.u[2] -= hi_top;
+
+        gl64_t ret;
+        ret.reduce(w);
+        ret.to();
+        return ret;
+    }
+
+private:
+    template<int unroll> // 1, 2 or 3
+    static __device__ __noinline__ gl64_t sqr_n_mul(gl64_t s, uint32_t n, gl64_t m)
+    {
+        if (unroll&1) {
+            s.mul(s);
+            n--;
+        }
+        if (unroll > 1) {
+            #pragma unroll 1
+            do {
+                s.mul(s);
+                s.mul(s);
+            } while (n -= 2);
+        }
+        s.mul(m);
+
+        return s;
+    }
+
+public:
+    inline gl64_t reciprocal() const
+    {
+        gl64_t t0, t1;
+
+        t1 = sqr_n_mul<1>(*this, 1, *this); // 0b11
+        t0 = sqr_n_mul<2>(t1, 2,  t1);      // 0b1111
+        t0 = sqr_n_mul<2>(t0, 2,  t1);      // 0b111111
+        t1 = sqr_n_mul<2>(t0, 6,  t0);      // 0b111111111111
+        t1 = sqr_n_mul<2>(t1, 12, t1);      // 0b111111111111111111111111
+        t1 = sqr_n_mul<2>(t1, 6,  t0);      // 0b111111111111111111111111111111
+        t1 = sqr_n_mul<1>(t1, 1,  *this);   // 0b1111111111111111111111111111111
+        t1 = sqr_n_mul<2>(t1, 32, t1);      // 0b111111111111111111111111111111101111111111111111111111111111111
+        t1 = sqr_n_mul<1>(t1, 1,  *this);   // 0b1111111111111111111111111111111011111111111111111111111111111111
+        t1.to();
+
+        return t1;
+    }
+    friend inline gl64_t operator/(int one, const gl64_t& a)
+    {   assert(one == 1); return a.reciprocal();   }
+    friend inline gl64_t operator/(const gl64_t& a, const gl64_t& b)
+    {   return a * b.reciprocal();   }
+    inline gl64_t& operator/=(const gl64_t& a)
+    {   return *this *= a.reciprocal();   }
+
+    inline gl64_t heptaroot() const
+    {
+        gl64_t t0, t1;
+
+        t1 = sqr_n_mul<3>(*this, 3, *this); // 0b1001
+        t0 = sqr_n_mul<2>(t1, 6,  t1);      // 0b1001001001
+        t0 = sqr_n_mul<2>(t0, 12, t0);      // 0b1001001001001001001001
+        t0 = sqr_n_mul<2>(t0, 6,  t1);      // 0b1001001001001001001001001001
+        t1 = sqr_n_mul<2>(t0, 4,  *this);   // 0b10010010010010010010010010010001
+        t1 = sqr_n_mul<2>(t1, 28, t0);      // 0b100100100100100100100100100100011001001001001001001001001001
+        t1 = sqr_n_mul<2>(t1, 2,  t0);      // 0b10010010010010010010010010010001101101101101101101101101101101
+        t1 = sqr_n_mul<1>(t1, 1,  *this);   // 0b100100100100100100100100100100011011011011011011011011011011011
+        t1 = sqr_n_mul<1>(t1, 1,  *this);   // 0b1001001001001001001001001001000110110110110110110110110110110111
+        t1.to();
+
+        return t1;
+    }
+
+    inline void shfl_bfly(uint32_t laneMask)
+    {
+        uint32_t idx = (threadIdx.x ^ laneMask) << 2;
+
+        u[0] = __builtin_amdgcn_ds_bpermute(idx, u[0]);
+        u[1] = __builtin_amdgcn_ds_bpermute(idx, u[1]);
+    }
+
+# undef inline
+
+public:
+    friend inline bool operator==(gl64_t a, gl64_t b)
+    {   return a.ul == b.ul;   }
+    friend inline bool operator!=(gl64_t a, gl64_t b)
+    {   return a.ul != b.ul;   }
+# if defined(_GLIBCXX_IOSTREAM) || defined(_IOSTREAM_) // non-standard
+    friend std::ostream& operator<<(std::ostream& os, const gl64_t& obj)
+    {
+        auto f = os.flags();
+        os << "0x" << std::hex << obj.val;
+        os.flags(f);
+        return os;
+    }
+# endif
+};
+
+# undef v_subb_co_u32
+# undef v_addc_co_u32
+# undef S_OP
+# undef __GL64_T_XSTR
+# undef __GL64_T_STR
+#endif /* __SPPARK_FF_GL64_T_HIP__ */

--- a/ff/gl64_t.hip
+++ b/ff/gl64_t.hip
@@ -7,7 +7,7 @@
 
 # include <cstdint>
 
-# if defined(__GFX10__) || defined(__GFX11__) //? || defined(__GFX12__)
+# if defined(__GFX10__) || defined(__GFX11__) || defined(__GFX12__)
 #  define v_addc_co_u32 "v_add_co_ci_u32 "
 #  define v_subb_co_u32 "v_sub_co_ci_u32 "
 # elif defined(__GFX9__)

--- a/ff/goldilocks.hpp
+++ b/ff/goldilocks.hpp
@@ -5,4 +5,7 @@
 #ifdef __CUDACC__
 # include "gl64_t.cuh"  // CUDA device-side field types
 typedef gl64_t fr_t;
+#elif defined(__HIPCC__)
+# include "gl64_t.hip"
+typedef gl64_t fr_t;
 #endif

--- a/ff/mont32_t.hip
+++ b/ff/mont32_t.hip
@@ -1,0 +1,431 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(__HIPCC__) && !defined(__SPPARK_FF_MONT32_T_HIP__)
+#define __SPPARK_FF_MONT32_T_HIP__
+
+# include <cstdint>
+
+# if defined(__GFX10__) || defined(__GFX11__) //? || defined(__GFX12__)
+#  define v_addc_co_u32 "v_add_co_ci_u32 "
+#  define v_subb_co_u32 "v_sub_co_ci_u32 "
+# elif defined(__GFX9__)
+#  define v_addc_co_u32 "v_addc_co_u32 "
+#  define v_subb_co_u32 "v_subb_co_u32 "
+# elif !defined(__HIP_DEVICE_COMPILE__)
+#  define v_addc_co_u32 "v_dummy "
+#  define v_subb_co_u32 "v_dummy "
+# else
+#  error "unsupported GFX architecture"
+# endif
+
+# define __MONT32_T_STR(x) #x
+# define __MONT32_T_XSTR(x) __MONT32_T_STR(x)
+# define S_OP(op) "s_" #op "_b" __MONT32_T_XSTR(__AMDGCN_WAVEFRONT_SIZE) " "
+
+# define inline __device__ __forceinline__
+
+template<const size_t N, const uint32_t MOD, const uint32_t M0,
+         const uint32_t RR, const uint32_t ONE>
+class mont32_t {
+private:
+    uint32_t val;
+
+# if __AMDGCN_WAVEFRONT_SIZE == 64
+    using cond_t = uint64_t;
+# else
+    using cond_t = uint32_t;
+# endif
+
+public:
+    using mem_t = mont32_t;
+    static const uint32_t degree = 1;
+    static constexpr size_t __device__ bit_length()     { return N;  }
+
+    inline uint32_t& operator[](size_t i)               { return val; (void)i; }
+    inline uint32_t& operator*()                        { return val; }
+    inline const uint32_t& operator[](size_t i) const   { return val; (void)i; }
+    inline uint32_t operator*() const                   { return val; }
+    inline size_t len() const                           { return 1;   }
+
+    inline mont32_t() {}
+    inline mont32_t(const uint32_t *p)                  { val = *p; }
+    // this is used in constant declaration, e.g. as mont32_t{11}
+    __host__ __device__ constexpr mont32_t(int a)       : val(((uint64_t)a << 32) % MOD) {}
+    __host__ __device__ constexpr mont32_t(uint32_t a)  : val(a) {}
+
+    inline operator uint32_t() const        { return mul_by_1(); }
+    inline void store(uint32_t *p) const    { *p = mul_by_1();   }
+    inline mont32_t& operator=(uint32_t b)  { val = b; to(); return *this; }
+
+    inline mont32_t& operator+=(const mont32_t b)
+    {
+        val += b.val;
+        if (N == 32) {
+            if (val < b.val || val >= MOD)  val -= MOD;
+        } else {
+            if (val >= MOD)                 val -= MOD;
+        }
+
+        return *this;
+    }
+    friend inline mont32_t operator+(mont32_t a, const mont32_t b)
+    {   return a += b;   }
+
+    inline mont32_t& operator<<=(uint32_t l)
+    {
+        if (N == 32) {
+            while (l--) {
+                bool carry = val >> 31;
+                val <<= 1;
+                if (carry || val >= MOD)    val -= MOD;
+            }
+        } else {
+            while (l--) {
+                val <<= 1;
+                if (val >= MOD)             val -= MOD;
+            }
+        }
+
+        return *this;
+    }
+    friend inline mont32_t operator<<(mont32_t a, uint32_t l)
+    {   return a <<= l;   }
+
+    inline mont32_t& operator>>=(uint32_t r)
+    {
+        while (r >= 32) {
+            val = mul_by_1();
+            r -= 32;
+        }
+
+        if (r > 2) {
+            uint32_t red = (val * M0) & ((1<<r) - 1);
+            uint64_t tmp = (uint64_t)MOD * red + val;
+
+            val = (uint32_t)(tmp >> r);
+        } else if (N == 32) {
+            while (r--) {
+                uint64_t tmp = val&1 ? MOD : 0;
+
+                tmp += val;
+                val = (uint32_t)(tmp >> 1);
+            }
+        } else {
+            while (r--) {
+                if (val&1)  val += MOD;
+                val >>= 1;
+            }
+        }
+
+        return *this;
+    }
+    friend inline mont32_t operator>>(mont32_t a, uint32_t r)
+    {   return a >>= r;   }
+
+    inline mont32_t& operator-=(const mont32_t b)
+    {
+        bool borrow = val < b.val;
+
+        val -= b.val;
+        if (borrow)
+            val += MOD;
+
+        return *this;
+    }
+    friend inline mont32_t operator-(mont32_t a, const mont32_t b)
+    {   return a -= b;   }
+
+    inline mont32_t cneg(bool flag)
+    {
+        if (flag && val != 0)
+            val = MOD - val;
+
+        return *this;
+    }
+    static inline mont32_t cneg(mont32_t a, bool flag)
+    {   return a.cneg(flag);   }
+    inline mont32_t operator-() const
+    {   return cneg(*this, true);   }
+
+    static inline const mont32_t one()  { return mont32_t{ONE}; }
+    inline bool is_one() const          { return val == ONE;    }
+    inline bool is_zero() const         { return val == 0;      }
+    inline void zero()                  { val = 0;              }
+
+    friend inline mont32_t czero(const mont32_t a, int set_z)
+    {   return set_z ? mont32_t{0u} : a;   }
+
+    static inline mont32_t csel(const mont32_t a, const mont32_t b, int sel_a)
+    {   return sel_a ? a : b;   }
+
+private:
+    static inline uint32_t final_sub(uint32_t val, cond_t carry)
+    {
+        if (N == 32) {
+            cond_t borrow;
+            uint32_t tmp;
+
+            asm("v_sub_co_u32  %0, %1, %2, %3" : "=v"(tmp), "=s"(borrow)
+                                               : "v"(val), "v"(MOD));
+#if defined(__GFX11__)
+            asm(S_OP(or_not1) "%0, %0, %1"     : "+s"(carry) : "s"(borrow));
+#else
+            asm(S_OP(orn2)    "%0, %0, %1"     : "+s"(carry) : "s"(borrow));
+#endif
+            asm("v_cndmask_b32 %0, %0, %1, %2" : "+v"(val)
+                                               : "v"(tmp), "s"(carry));
+        } else {
+            if (val >= MOD)
+                val -= MOD;
+        }
+
+        return val;
+    }
+
+    inline mont32_t& mul(const mont32_t b)
+    {
+        uint64_t tmp = (uint64_t)val * b.val;
+        uint32_t red = (uint32_t)tmp * M0;
+        cond_t carry;
+
+        asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(tmp), "=s"(carry)
+                                               : "v"(red), "v"(MOD));
+        val = final_sub(tmp >> 32, carry);
+
+        return *this;
+    }
+
+    inline uint32_t mul_by_1() const
+    {
+        uint32_t red = val * M0;
+        uint64_t tmp;
+        cond_t carry;
+
+        asm("v_mad_u64_u32 %0, %1, %2, %3, %4" : "=v"(tmp), "=s"(carry)
+                                               : "v"(red), "v"(MOD), "v"((uint64_t)val));
+        return tmp >> 32;
+    }
+
+public:
+    friend inline mont32_t operator*(mont32_t a, const mont32_t b)
+    {   return a.mul(b);   }
+    inline mont32_t& operator*=(const mont32_t a)
+    {   return mul(a);   }
+
+    // raise to a variable power, variable in respect to threadIdx,
+    // but mind the ^ operator's precedence!
+    inline mont32_t& operator^=(uint32_t p)
+    {
+        mont32_t sqr = *this;
+        *this = csel(val, ONE, p&1);
+
+        #pragma unroll 1
+        while (p >>= 1) {
+            sqr.mul(sqr);
+            if (p&1)
+                mul(sqr);
+        }
+
+        return *this;
+    }
+    friend inline mont32_t operator^(mont32_t a, uint32_t p)
+    {   return a ^= p;   }
+    inline mont32_t operator()(uint32_t p)
+    {   return *this^p;   }
+
+    // raise to a constant power, e.g. x^7, to be unrolled at compile time
+    inline mont32_t& operator^=(int p)
+    {
+        assert(p >= 2);
+
+        if (p == 7) {
+            mont32_t temp = sqr_n_mul(*this, 1, *this);
+            *this = sqr_n_mul(temp, 1, *this);
+            return *this;
+        }
+
+        mont32_t sqr = *this;
+        if ((p&1) == 0) {
+            do {
+                sqr.mul(sqr);
+                p >>= 1;
+            } while ((p&1) == 0);
+            *this = sqr;
+        }
+        for (p >>= 1; p; p >>= 1) {
+            sqr.mul(sqr);
+            if (p&1)
+                mul(sqr);
+        }
+
+        return *this;
+    }
+    friend inline mont32_t operator^(mont32_t a, int p)
+    {   return a ^= p;   }
+    inline mont32_t operator()(int p)
+    {   return *this^p;   }
+    friend inline mont32_t sqr(mont32_t a)
+    {   return a.sqr();   }
+    inline mont32_t& sqr()
+    {   return mul(*this);   }
+
+    inline void to()   { mul(RR); }
+    inline void from() { val = mul_by_1(); }
+
+    template<size_t T>
+    static inline mont32_t dot_product(const mont32_t a[T], const mont32_t b[T])
+    {
+        union { uint64_t acc; uint32_t ul[2]; };
+        cond_t carry;
+
+        acc = *a[0] * (uint64_t)*b[0];
+
+        if (N == 32) {
+            for (size_t i = 1; i < T; i++) {
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i]), "v"(*b[i]));
+                ul[1] = final_sub(ul[1], carry);
+            }
+        } else {
+            size_t i = 1;
+
+            if ((T&1) == 0) {
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i]), "v"(*b[i]));
+                i++;
+            }
+            for (; i < T; i += 2) {
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i]), "v"(*b[i]));
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i+1]), "v"(*b[i+1]));
+                ul[1] = final_sub(ul[1], carry);
+            }
+        }
+
+        uint32_t red = ul[0] * M0;
+        asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                               : "v"(red), "v"(MOD));
+        return final_sub(ul[1], carry);
+    }
+
+    template<size_t T>
+    static inline mont32_t dot_product(mont32_t a0, mont32_t b0,
+                                       const mont32_t a[T-1], const mont32_t *b,
+                                       size_t stride_b = 1)
+    {
+        union { uint64_t acc; uint32_t ul[2]; };
+        cond_t carry;
+
+        acc = *a0 * (uint64_t)*b0;
+
+        if (N == 32) {
+            for (size_t i = 0; i < T-1; i++, b += stride_b) {
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i]), "v"(*b[0]));
+                ul[1] = final_sub(ul[1], carry);
+            }
+        } else {
+            size_t i = 0;
+
+            if ((T&1) == 0) {
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i]), "v"(*b[0]));
+                i++, b += stride_b;
+            }
+            for (; i < T-1; i += 2) {
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i]), "v"(*b[0]));
+                b += stride_b;
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                                       : "v"(*a[i+1]), "v"(*b[0]));
+                b += stride_b;
+                ul[1] = final_sub(ul[1], carry);
+            }
+        }
+
+        uint32_t red = ul[0] * M0;
+        asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(acc), "=s"(carry)
+                                               : "v"(red), "v"(MOD));
+        return final_sub(ul[1], carry);
+    }
+
+    inline mont32_t reciprocal() const
+    {   return *this ^ (MOD-2);   }
+    friend inline mont32_t operator/(int one, mont32_t a)
+    {   assert(one == 1); return a.reciprocal();   }
+    friend inline mont32_t operator/(mont32_t a, mont32_t b)
+    {   return a * b.reciprocal();   }
+    inline mont32_t& operator/=(const mont32_t a)
+    {   return *this *= a.reciprocal();   }
+
+    inline void shfl_bfly(uint32_t laneMask)
+    {
+        uint32_t idx = (threadIdx.x ^ laneMask) << 2;
+
+        val = __builtin_amdgcn_ds_bpermute(idx, val);
+    }
+
+protected:
+    static inline mont32_t sqr_n(mont32_t s, uint32_t n)
+    {
+        if (N == 32 || M0 > MOD) {
+            #pragma unroll 2
+            while (n--)
+                s.sqr();
+        } else {
+            #pragma unroll 2
+            while (n--) {
+                uint64_t tmp = (uint64_t)s.val * s.val;
+                uint32_t red = (uint32_t)tmp * M0;
+                cond_t carry;
+
+                asm("v_mad_u64_u32 %0, %1, %2, %3, %0" : "+v"(tmp), "=s"(carry)
+                                                       : "v"(red), "v"(MOD));
+                s.val = tmp >> 32;
+
+                if (n&1)
+                    s.val = final_sub(s.val, carry);
+            }
+        }
+
+        return s;
+    }
+
+    static inline mont32_t sqr_n_mul(mont32_t s, uint32_t n, mont32_t m)
+    {
+        s = sqr_n(s, n);
+        s.mul(m);
+
+        return s;
+    }
+
+# undef inline
+
+public:
+    friend inline bool operator==(mont32_t a, mont32_t b)
+    {   return a.val == b.val;   }
+    friend inline bool operator!=(mont32_t a, mont32_t b)
+    {   return a.val != b.val;   }
+
+# if defined(_GLIBCXX_IOSTREAM) || defined(_IOSTREAM_) // non-standard
+    friend std::ostream& operator<<(std::ostream& os, const mont32_t& obj)
+    {
+        auto f = os.flags();
+        uint32_t red = obj.val * M0;
+        uint64_t v = obj.val + red * (uint64_t)MOD;
+        os << "0x" << std::hex << (uint32_t)(v >> 32);
+        os.flags(f);
+        return os;
+    }
+# endif
+};
+
+# undef v_subb_co_u32
+# undef v_addc_co_u32
+# undef S_OP
+# undef __MONT32_T_XSTR
+# undef __MONT32_T_STR
+#endif /* __SPPARK_FF_MONT32_T_HIP__ */

--- a/ff/mont32_t.hip
+++ b/ff/mont32_t.hip
@@ -7,7 +7,7 @@
 
 # include <cstdint>
 
-# if defined(__GFX10__) || defined(__GFX11__) //? || defined(__GFX12__)
+# if defined(__GFX10__) || defined(__GFX11__) || defined(__GFX12__)
 #  define v_addc_co_u32 "v_add_co_ci_u32 "
 #  define v_subb_co_u32 "v_sub_co_ci_u32 "
 # elif defined(__GFX9__)

--- a/ff/mont_t.hip
+++ b/ff/mont_t.hip
@@ -12,7 +12,7 @@
 // This is a trimmed-down version tailored for use in NTT only.
 //
 
-# if defined(__GFX10__) || defined(__GFX11__) //? || defined(__GFX12__)
+# if defined(__GFX10__) || defined(__GFX11__) || defined(__GFX12__)
 #  define v_addc_co_u32 "v_add_co_ci_u32 "
 #  define v_subb_co_u32 "v_sub_co_ci_u32 "
 # elif defined(__GFX9__)

--- a/ff/mont_t.hip
+++ b/ff/mont_t.hip
@@ -1,0 +1,340 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(__HIPCC__) && !defined(__SPPARK_FF_MONT_T_HIP__)
+# define __SPPARK_FF_MONT_T_HIP__
+
+# include <cstddef>
+# include <cstdint>
+
+//
+// This is a trimmed-down version tailored for use in NTT only.
+//
+
+# if defined(__GFX10__) || defined(__GFX11__) //? || defined(__GFX12__)
+#  define v_addc_co_u32 "v_add_co_ci_u32 "
+#  define v_subb_co_u32 "v_sub_co_ci_u32 "
+# elif defined(__GFX9__)
+#  define v_addc_co_u32 "v_addc_co_u32 "
+#  define v_subb_co_u32 "v_subb_co_u32 "
+# elif !defined(__HIP_DEVICE_COMPILE__)
+#  define v_addc_co_u32 "v_dummy "
+#  define v_subb_co_u32 "v_dummy "
+# else
+#  error "unsupported GFX architecture"
+# endif
+
+# define __MONT_T_STR(x) #x
+# define __MONT_T_XSTR(x) __MONT_T_STR(x)
+# define S_OP(op) "s_" #op "_b" __MONT_T_XSTR(__AMDGCN_WAVEFRONT_SIZE) " "
+
+# define inline __device__ __forceinline__
+
+//
+// To instantiate declare modulus as __device__ __constant___ const and
+// complement it with its factual bit-length and the corresponding 32-bit
+// Motgomery factor. Bit-length has to be such that (N+31)/32 is even
+// and not less than 4.
+//
+template<const size_t N, const uint32_t MOD[(N+31)/32], const uint32_t& M0,
+         const uint32_t RR[(N+31)/32], const uint32_t ONE[(N+31)/32],
+         const uint32_t MODx[(N+31)/32] = MOD>
+class __align__(((N+63)/64)&1 ? 8 : 16) mont_t {
+public:
+    static const size_t nbits = N;
+    static constexpr size_t __device__ bit_length() { return N; }
+    static const uint32_t degree = 1;
+    using mem_t = mont_t;
+protected:
+    static const size_t n = (N+31)/32;
+private:
+    uint32_t val[n];
+
+# if __AMDGCN_WAVEFRONT_SIZE == 64
+    using cond_t = uint64_t;
+# else
+    using cond_t = uint32_t;
+# endif
+
+    static __device__ __noinline__ void noop()          { asm("");       }
+
+    inline operator const uint32_t*() const             { return val;    }
+    inline operator uint32_t*()                         { return val;    }
+
+public:
+    inline uint32_t& operator[](size_t i)               { return val[i]; }
+    inline const uint32_t& operator[](size_t i) const   { return val[i]; }
+    inline size_t len() const                           { return n;      }
+
+    inline mont_t() {}
+    inline mont_t(const uint32_t p[n])
+    {
+        for (size_t i=0; i<n; i++)
+            val[i] = p[i];
+    }
+
+    __host__ mont_t(const uint64_t p[n/2])
+    {
+        for (size_t i=0; i<n/2; i++) {
+            val[2*i]     = (uint32_t)(p[i]);
+            val[2*i + 1] = (uint32_t)(p[i] >> 32);
+        }
+    }
+
+    inline void store(uint32_t p[n]) const
+    {
+        for (size_t i=0; i<n; i++)
+            p[i] = val[i];
+    }
+
+    inline mont_t& operator+=(const mont_t& b)
+    {
+        cond_t carry;
+
+        asm("v_add_co_u32   %0, %1, %0, %2"         : "+v"(val[0]), "=s"(carry)
+                                                    : "v"(b[0]));
+        for (size_t i=1; i<n; i++)
+            asm( v_addc_co_u32 "%0, %1, %0, %2, %1" : "+v"(val[i]), "+s"(carry)
+                                                    : "v"(b[i]));
+        final_sub(carry);
+
+        return *this;
+    }
+    friend inline mont_t operator+(mont_t a, const mont_t& b)
+    {   return a += b;   }
+
+    inline mont_t& operator-=(const mont_t& b)
+    {
+        cond_t borrow, carry;
+        uint32_t tmp[n];
+
+        asm("v_sub_co_u32   %0, %1, %0, %2"         : "+v"(val[0]), "=s"(borrow)
+                                                    : "v"(b[0]));
+        for (size_t i=1; i<n; i++)
+            asm( v_subb_co_u32 "%0, %1, %0, %2, %1" : "+v"(val[i]), "+s"(borrow)
+                                                    : "v"(b[i]));
+
+        asm("v_add_co_u32   %0, %1, %2, %3"         : "=v"(tmp[0]), "=s"(carry)
+                                                    : "v"(val[0]), "v"(MOD[0]));
+        for (size_t i=1; i<n; i++) {
+            asm( v_addc_co_u32 "%0, %1, %2, %3, %1" : "=v"(tmp[i]), "+s"(carry)
+                                                    : "v"(val[i]), "v"(MOD[i]));
+            asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(val[i-1])
+                                                    : "v"(tmp[i-1]), "s"(borrow));
+        }
+        asm("v_cndmask_b32  %0, %0, %1, %2"         : "+v"(val[n-1])
+                                                    : "v"(tmp[n-1]), "s"(borrow));
+        noop();
+
+        return *this;
+    }
+    friend inline mont_t operator-(mont_t a, const mont_t& b)
+    {   return a -= b;   }
+
+    friend inline mont_t operator*(const mont_t& a, const mont_t& b)
+    {
+        union { uint64_t ul; uint32_t u[2]; };
+        cond_t carry = 0;
+        mont_t ret;
+        size_t i;
+
+        uint64_t mx = b[0];
+        ul = mx * a[0];
+        ret[0] = u[0];
+        for (i=1; i<n; i++) {
+            ul = mx * a[i] + u[1];
+            ret[i] = u[0];
+        }
+        auto top = u[1];
+
+        for (size_t j=0; ; ) {
+            mx = M0 * ret[0];
+            ul = mx * MOD[0] + ret[0];
+            for (i=1; i<n; i++) {
+                ul = (mx * MOD[i] + u[1]) + ret[i];
+                ret[i-1] = u[0];
+            }
+            if (N%32 != 0) {
+                ret[n-1] = u[1] + top;
+            } else {
+                asm( v_addc_co_u32 "%0, %1, %2, %3, %1" : "=v"(ret[n-1]), "+s"(carry)
+                                                        : "v"(u[1]), "v"(top));
+            }
+
+            if (++j == n)
+                break;
+
+            mx = b[j];
+            ul = mx * a[0] + ret[0];
+            ret[0] = u[0];
+            for (i=1; i<n; i++) {
+                ul = (mx * a[i] + u[1]) + ret[i];
+                ret[i] = u[0];
+            }
+            if (N%32 != 0) {
+                top = u[1];
+            } else {
+                asm( v_addc_co_u32 "%0, %1, %2, 0, %1"  : "=v"(top), "+s"(carry)
+                                                        : "v"(u[1]));
+            }
+        }
+
+        ret.final_sub(carry);
+
+        return ret;
+    }
+    inline mont_t& operator*=(const mont_t& a)
+    {   return *this = *this * a;   }
+
+    inline mont_t& sqr()
+    {   return *this = *this * *this;   }
+
+    // raise to a variable power, variable in respect to threadIdx,
+    // but mind the ^ operator's precedence!
+    inline mont_t& operator^=(uint32_t p)
+    {
+        mont_t sqr = *this;
+        *this = csel(*this, one(), p&1);
+
+        #pragma unroll 1
+        while (p >>= 1) {
+            sqr.sqr();
+            if (p&1)
+                *this *= sqr;
+        }
+
+        return *this;
+    }
+    friend inline mont_t operator^(mont_t a, uint32_t p)
+    {   return a ^= p;   }
+    inline mont_t operator()(uint32_t p)
+    {   return *this^p;   }
+
+    // raise to a constant power, e.g. x^7, to be unrolled at compile time
+    inline mont_t& operator^=(int p)
+    {
+        assert(p > 1);
+
+        mont_t sqr = *this;
+        if ((p&1) == 0) {
+            do {
+                sqr.sqr();
+                p >>= 1;
+            } while ((p&1) == 0);
+            *this = sqr;
+        }
+        for (p >>= 1; p; p >>= 1) {
+            sqr.sqr();
+            if (p&1)
+                *this *= sqr;
+        }
+        return *this;
+    }
+    friend inline mont_t operator^(mont_t a, int p)
+    {   return p == 2 ? a *= a : a ^= p;   }
+    inline mont_t operator()(int p)
+    {   return *this^p;   }
+    friend inline mont_t sqr(const mont_t& a)
+    {   return a^2;   }
+
+    inline void to()    { mont_t t = RR * *this; *this = t; }
+    inline void from()  { mul_by_1(); }
+
+    static inline const mont_t& one()
+    {   return *reinterpret_cast<const mont_t*>(ONE);   }
+
+    inline void zero()
+    {
+        if (n%4 == 0) {
+            uint4* p = reinterpret_cast<uint4*>(val);
+            for (size_t i=0; i<sizeof(val)/(sizeof(uint4)); i++)
+                p[i] = uint4{0, 0, 0, 0};
+        } else {
+            uint64_t* p = reinterpret_cast<uint64_t*>(val);
+            for (size_t i=0; i<sizeof(val)/(sizeof(uint64_t)); i++)
+                p[i] = 0;
+        }
+    }
+
+    friend inline mont_t czero(const mont_t& a, int set_z)
+    {
+        mont_t ret;
+        cond_t cond;
+
+        asm("v_cmp_ne_u32  %0, %1, 0"           : "=s"(cond)
+                                                : "v"(set_z));
+        for (size_t i=0; i<n; i++)
+            asm("v_cndmask_b32 %0, %1, 0, %2"   : "=v"(ret[i])
+                                                : "v"(a[i]), "s"(cond));
+        return ret;
+    }
+
+    static inline mont_t csel(const mont_t& a, const mont_t& b, int sel_a)
+    {
+        mont_t ret;
+        cond_t cond;
+
+        asm("v_cmp_ne_u32  %0, %1, 0"           : "=s"(cond)
+                                                : "v"(sel_a));
+        for (size_t i=0; i<n; i++)
+            asm("v_cndmask_b32 %0, %1, %2, %3"  : "=v"(ret[i])
+                                                : "v"(b[i]), "v"(a[i]), "s"(cond));
+        return ret;
+    }
+
+    inline void shfl_bfly(uint32_t laneMask)
+    {
+        uint32_t idx = (threadIdx.x ^ laneMask) << 2;
+
+        for (size_t i=0; i<n; i++)
+            val[i] = __builtin_amdgcn_ds_bpermute(idx, val[i]);
+    }
+
+private:
+    inline void final_sub(cond_t carry)
+    {
+        cond_t borrow;
+        uint32_t tmp[n];
+
+        asm("v_sub_co_u32   %0, %1, %2, %3"         : "=v"(tmp[0]), "=s"(borrow)
+                                                    : "v"(val[0]), "v"(MOD[0]));
+        for (size_t i=1; i<n; i++)
+            asm( v_subb_co_u32 "%0, %1, %2, %3, %1" : "=v"(tmp[i]), "+s"(borrow)
+                                                    : "v"(val[i]), "v"(MOD[i]));
+#if defined(__GFX11__)
+        asm(S_OP(or_not1)  "%0, %0, %1"             : "+s"(carry)
+                                                    : "s"(borrow));
+#else
+        asm(S_OP(orn2)     "%0, %0, %1"             : "+s"(carry)
+                                                    : "s"(borrow));
+#endif
+        for (size_t i=0; i<n; i++)
+            asm("v_cndmask_b32  %0, %0, %1, %2"     : "+v"(val[i])
+                                                    : "v"(tmp[i]), "s"(carry));
+        noop();
+    }
+
+    inline void mul_by_1()
+    {
+        union { uint64_t ul; uint32_t u[2]; };
+
+        for (size_t j=0; j<n; j++) {
+            uint64_t mx = M0 * val[0];
+            ul = mx * MOD[0] + val[0];
+            for (size_t i=1; i<n; i++) {
+                ul = (mx * MOD[i] + u[1]) + val[i];
+                val[i-1] = u[0];
+            }
+            val[n-1] = u[1];
+        }
+    }
+};
+
+# undef inline
+# undef v_subb_co_u32
+# undef v_addc_co_u32
+# undef S_OP
+# undef __MONT_T_XSTR
+# undef __MONT_T_STR
+#endif

--- a/ntt/kernels/ct_mixed_radix_narrow.cu
+++ b/ntt/kernels/ct_mixed_radix_narrow.cu
@@ -10,7 +10,7 @@ void _CT_NTT(const unsigned int radix, const unsigned int lg_domain_size,
              const fr_t* d_radix6_twiddles, const fr_t* d_radixX_twiddles,
              bool is_intt, const fr_t d_domain_size_inverse)
 {
-#if (__CUDACC_VER_MAJOR__-0) >= 11
+#if (__CUDACC_VER_MAJOR__-0) >= 11 || defined(__clang__)
     __builtin_assume(lg_domain_size <= MAX_LG_DOMAIN_SIZE);
     __builtin_assume(radix <= 10);
     __builtin_assume(iterations <= radix);

--- a/ntt/kernels/ct_mixed_radix_narrow.cu
+++ b/ntt/kernels/ct_mixed_radix_narrow.cu
@@ -85,6 +85,7 @@ void _CT_NTT(const unsigned int radix, const unsigned int lg_domain_size,
         r[1][z] = r[0][z] - t;
         r[0][z] = r[0][z] + t;
     }
+    noop();
 
     #pragma unroll 1
     for (unsigned int s = 1; s < min(iterations, 6u); s++) {
@@ -108,6 +109,7 @@ void _CT_NTT(const unsigned int radix, const unsigned int lg_domain_size,
             r[1][z] = r[0][z] - t;
             r[0][z] = r[0][z] + t;
         }
+        noop();
     }
 
     #pragma unroll 1
@@ -140,6 +142,7 @@ void _CT_NTT(const unsigned int radix, const unsigned int lg_domain_size,
             r[1][z] = r[0][z] - t;
             r[0][z] = t + r[0][z];
         }
+        noop();
 
         __syncthreads();
     }

--- a/ntt/kernels/ct_mixed_radix_wide.cu
+++ b/ntt/kernels/ct_mixed_radix_wide.cu
@@ -12,7 +12,7 @@ void _CT_NTT(const unsigned int radix, const unsigned int lg_domain_size,
              const unsigned int intermediate_twiddle_shift,
              const bool is_intt, const fr_t d_domain_size_inverse)
 {
-#if (__CUDACC_VER_MAJOR__-0) >= 11
+#if (__CUDACC_VER_MAJOR__-0) >= 11 || defined(__clang__)
     __builtin_assume(lg_domain_size <= MAX_LG_DOMAIN_SIZE);
     __builtin_assume(radix <= 10);
     __builtin_assume(iterations <= radix);

--- a/ntt/kernels/gs_mixed_radix_narrow.cu
+++ b/ntt/kernels/gs_mixed_radix_narrow.cu
@@ -10,7 +10,7 @@ void _GS_NTT(const unsigned int radix, const unsigned int lg_domain_size,
              const fr_t* d_radix6_twiddles, const fr_t* d_radixX_twiddles,
              bool is_intt, const fr_t d_domain_size_inverse)
 {
-#if (__CUDACC_VER_MAJOR__-0) >= 11
+#if (__CUDACC_VER_MAJOR__-0) >= 11 || defined(__clang__)
     __builtin_assume(lg_domain_size <= MAX_LG_DOMAIN_SIZE);
     __builtin_assume(radix <= 10);
     __builtin_assume(iterations <= radix);

--- a/ntt/kernels/gs_mixed_radix_narrow.cu
+++ b/ntt/kernels/gs_mixed_radix_narrow.cu
@@ -83,6 +83,7 @@ void _GS_NTT(const unsigned int radix, const unsigned int lg_domain_size,
             r[0][z] = fr_t::csel(r[0][z], t, pos);
             r[1][z] = fr_t::csel(t, r[1][z], pos);
         }
+        noop();
     }
 
     #pragma unroll 1
@@ -107,6 +108,7 @@ void _GS_NTT(const unsigned int radix, const unsigned int lg_domain_size,
             r[0][z] = fr_t::csel(r[0][z], t, pos);
             r[1][z] = fr_t::csel(t, r[1][z], pos);
         }
+        noop();
     }
 
     #pragma unroll
@@ -115,6 +117,7 @@ void _GS_NTT(const unsigned int radix, const unsigned int lg_domain_size,
         r[0][z] = r[0][z] + r[1][z];
         r[1][z] = t;
     }
+    noop();
 
     if (stage - iterations != 0) {
         index_t thread_ntt_pos = (tiz & inp_mask) >> (iterations - 1);

--- a/ntt/kernels/gs_mixed_radix_wide.cu
+++ b/ntt/kernels/gs_mixed_radix_wide.cu
@@ -12,7 +12,7 @@ void _GS_NTT(const unsigned int radix, const unsigned int lg_domain_size,
              const unsigned int intermediate_twiddle_shift,
              const bool is_intt, const fr_t d_domain_size_inverse)
 {
-#if (__CUDACC_VER_MAJOR__-0) >= 11
+#if (__CUDACC_VER_MAJOR__-0) >= 11 || defined(__clang__)
     __builtin_assume(lg_domain_size <= MAX_LG_DOMAIN_SIZE);
     __builtin_assume(radix <= lg_domain_size);
     __builtin_assume(stage <= lg_domain_size);

--- a/ntt/ntt.cuh
+++ b/ntt/ntt.cuh
@@ -12,6 +12,15 @@
 #include <util/rusterror.h>
 #include <util/gpu_t.cuh>
 
+#if defined(__NVCC__)
+# define noop()
+#elif defined(__HIPCC__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunused-function"
+__device__ __noinline__ static void noop() { asm(""); }
+# pragma clang diagnostic push
+#endif
+
 #include "parameters.cuh"
 #include "kernels.cu"
 

--- a/ntt/parameters.cuh
+++ b/ntt/parameters.cuh
@@ -43,10 +43,10 @@ typedef size_t index_t;
 #define WINDOW_SIZE (1 << LG_WINDOW_SIZE)
 #define WINDOW_NUM ((MAX_LG_DOMAIN_SIZE + LG_WINDOW_SIZE - 1) / LG_WINDOW_SIZE)
 
-__device__ __constant__ fr_t forward_radix6_twiddles[32];
-__device__ __constant__ fr_t inverse_radix6_twiddles[32];
+__device__ __constant__ fr_t forward_radix6_twiddles[32] = {};
+__device__ __constant__ fr_t inverse_radix6_twiddles[32] = {};
 
-#ifndef __CUDA_ARCH__
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
 # if defined(FEATURE_BLS12_377)
 #  include "parameters/bls12_377.h"
 # elif defined(FEATURE_BLS12_381)

--- a/ntt/parameters.cuh
+++ b/ntt/parameters.cuh
@@ -262,7 +262,7 @@ public:
 #endif
             (void)cudaFreeAsync(twiddles[1], gpu);
 
-            cudaSetDevice(current_id);
+            (void)cudaSetDevice(current_id);
         }
     }
 
@@ -276,7 +276,7 @@ private:
         all_params()
         {
             int current_id;
-            cudaGetDevice(&current_id);
+            (void)cudaGetDevice(&current_id);
 
             size_t nids = ngpus();
             forward.reserve(nids);
@@ -288,7 +288,7 @@ private:
             for (size_t id = 0; id < nids; id++)
                 inverse[id].sync();
 
-            cudaSetDevice(current_id);
+            (void)cudaSetDevice(current_id);
         }
     };
 

--- a/poc/go/poc.cu
+++ b/poc/go/poc.cu
@@ -15,7 +15,7 @@ struct Error {
 };
 
 extern "C"
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__HIP_DEVICE_COMPILE__)
 __declspec(dllexport)
 #else
 __attribute__((visibility("default")))

--- a/poc/ntt-cuda/build.rs
+++ b/poc/ntt-cuda/build.rs
@@ -59,9 +59,6 @@ fn main() {
 
     if env::var("DEP_SPPARK_TARGET").is_ok_and(|v| v.eq("rocm"))
     {
-        if !cfg!(feature = "gl64") && !cfg!(feature = "bb31") {
-            panic!("only gl64 and bb31 features are supported");
-        }
         env::set_var("HIP_PLATFORM", "amd");
         let mut hipcc = cc::Build::new();
         hipcc.compiler(env::var("HIPCC").unwrap_or("hipcc".to_string()));

--- a/poc/ntt-cuda/build.rs
+++ b/poc/ntt-cuda/build.rs
@@ -54,6 +54,34 @@ fn main() {
         fr = "FEATURE_BABY_BEAR";
     }
 
+    println!("cargo:rerun-if-changed=cuda");
+    println!("cargo:rerun-if-env-changed=CXXFLAGS");
+
+    if env::var("DEP_SPPARK_TARGET").is_ok_and(|v| v.eq("rocm"))
+    {
+        if !cfg!(feature = "gl64") && !cfg!(feature = "bb31") {
+            panic!("only gl64 and bb31 features are supported");
+        }
+        env::set_var("HIP_PLATFORM", "amd");
+        let mut hipcc = cc::Build::new();
+        hipcc.compiler(env::var("HIPCC").unwrap_or("hipcc".to_string()));
+        hipcc.cpp(true);
+        if cfg!(debug_assertions) {
+            hipcc.opt_level(1);
+        }
+        hipcc.flag("--offload-arch=native,gfx1102,gfx1101,gfx1100,gfx1034,gfx1032,gfx1031,gfx1030,gfx942,gfx90a,gfx908");
+        hipcc.flag("-parallel-jobs=11");
+        hipcc.define("TAKE_RESPONSIBILITY_FOR_ERROR_MESSAGE", None);
+        hipcc.define(fr, None);
+        if let Some(include) = env::var_os("DEP_SPPARK_ROOT") {
+            hipcc.include(include);
+            hipcc.flag("-include").flag("util/cuda2hip.hpp");
+        }
+        hipcc.file("cuda/ntt_api.cu").compile("ntt_rocm");
+
+        return;
+    }
+
     let mut nvcc = cc::Build::new();
     nvcc.cuda(true);
     nvcc.flag("-arch=sm_70");
@@ -74,7 +102,4 @@ fn main() {
         nvcc.include(include);
     }
     nvcc.file("cuda/ntt_api.cu").compile("ntt_cuda");
-
-    println!("cargo:rerun-if-changed=cuda");
-    println!("cargo:rerun-if-env-changed=CXXFLAGS");
 }

--- a/poc/ntt-cuda/cuda/ntt_api.cu
+++ b/poc/ntt-cuda/cuda/ntt_api.cu
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cuda.h>
-
 #if defined(FEATURE_BLS12_381)
 # include <ff/bls12-381.hpp>
 #elif defined(FEATURE_BLS12_377)

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -4,6 +4,7 @@
 
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -41,13 +42,27 @@ fn main() {
     // pass DEP_SPPARK_* variables to dependents
     println!("cargo:ROOT={}", base_dir.to_string_lossy());
 
-    // Detect if there is CUDA compiler and engage "cuda" feature accordingly
+    let all_gpus = base_dir.join("util/all_gpus.cpp");
+
+    println!("cargo:rerun-if-env-changed=NVCC");
     let nvcc = match env::var("NVCC") {
         Ok(var) => which::which(var),
         Err(_) => which::which("nvcc"),
     };
-    if nvcc.is_ok() {
-        let cuda_version = std::process::Command::new(nvcc.unwrap())
+
+    println!("cargo:rerun-if-env-changed=HIPCC");
+    let hipcc = match env::var("HIPCC") {
+        Ok(var) => which::which(var),
+        Err(_) => which::which("hipcc"),
+    };
+
+    // Detect if there is CUDA compiler and engage "cuda" feature accordingly,
+    // even if there is no Nvidia card, but unless there is ROCm compiler.
+    // In other words if you have both Nvidia and AMD cards installed, Nvidia
+    // will be preferred. To suppress it, set the NVCC environment variable
+    // to "off".
+    if let Ok(nvcc) = nvcc {
+        let cuda_version = Command::new(nvcc)
             .arg("--version")
             .output()
             .expect("impossible");
@@ -67,13 +82,105 @@ fn main() {
             panic!("Unsupported CUDA version {} < 11.4", v);
         }
 
-        let util_dir = base_dir.join("util");
+        let cuda_available = env::var_os("OUT_DIR")
+            .map(PathBuf::from)
+            .map(|p| p.join("cuda_available"))
+            .map(|mut p| {
+                p.set_extension(env::consts::EXE_EXTENSION);
+                p
+            })
+            .expect("$OUT_DIR is not set");
+
         let mut nvcc = cc::Build::new();
         nvcc.cuda(true);
-        nvcc.include(base_dir);
-        nvcc.file(util_dir.join("all_gpus.cpp"))
-            .compile("sppark_cuda");
-        println!("cargo:rustc-cfg=feature=\"cuda\"");
+
+        let _ = nvcc
+            .get_compiler()
+            .to_command()
+            .arg("src/cuda_available.cpp")
+            .arg("-o")
+            .arg(&cuda_available)
+            .status()
+            .expect("impossible");
+
+        let cuda_available = Command::new(cuda_available).status().expect("impossible");
+
+        if cuda_available.success() || hipcc.is_err() {
+            nvcc.include(&base_dir);
+            nvcc.file(&all_gpus)
+                .compile("sppark_cuda");
+            println!("cargo:rustc-cfg=feature=\"cuda\"");
+            println!("cargo:TARGET=cuda");
+            return;
+        }
     }
-    println!("cargo:rerun-if-env-changed=NVCC");
+
+    // Detect if there is ROCm compiler and engage "rocm" feature accordingly
+    if let Ok(hipcc) = hipcc {
+        env::set_var("HIP_PLATFORM", "amd");
+
+        let hipcc_version = Command::new(&hipcc)
+            .arg("--version")
+            .output()
+            .expect("impossible");
+        if !hipcc_version.status.success() {
+            panic!("{:?}", hipcc_version);
+        }
+        let hipcc_version = String::from_utf8(hipcc_version.stdout).unwrap();
+
+        let v = hipcc_version
+            .find("HIP version: ")
+            .expect(format!("{:?} is not a HIP compiler", hipcc).as_str())
+            + 13;
+        let w = hipcc_version[v..].find(|c: char| !c.is_digit(10))
+            .expect("can't parse \"HIP version: \" in `hipcc --version`");
+        let major_ver = hipcc_version[v..v + w].parse::<i32>().unwrap_or(0);
+        if major_ver < 6 {
+            panic!("Unsupported HIP version {} < 6", major_ver);
+        }
+
+        let x = hipcc_version
+            .find("InstalledDir: ")
+            .expect("can't find \"InstalledDir:\" in `hipcc --version`")
+            + 14;
+        let y = hipcc_version[x..]
+            .find(char::is_control)
+            .expect("can't parse \"InstalledDir:\" in `hipcc --version`");
+
+        let mut libpath: PathBuf = hipcc_version[x..x + y].into();
+
+        while libpath.pop() {
+            if libpath
+                .join("lib")
+                .join(if cfg!(unix) {
+                    "libamdhip64.so"
+                } else {
+                    "amdhip64.lib"
+                })
+                .try_exists()
+                .is_ok_and(|exists| exists)
+            {
+                libpath.push("lib");
+                break;
+            }
+        }
+
+        if libpath.parent().is_some() {
+            let mut ccmd = cc::Build::new();
+            ccmd.compiler(hipcc);
+            ccmd.cpp(true);
+            ccmd.include(&base_dir);
+            ccmd.flag("-include").flag("util/cuda2hip.hpp");
+            ccmd.file(&all_gpus)
+                .compile("sppark_rocm");
+            println!("cargo:rustc-cfg=feature=\"rocm\"");
+
+            println!(
+                "cargo:rustc-link-search=native={}",
+                libpath.to_string_lossy()
+            );
+            println!("cargo:rustc-link-lib=amdhip64");
+            println!("cargo:TARGET=rocm");
+        }
+    }
 }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -165,22 +165,22 @@ fn main() {
             }
         }
 
-        if libpath.parent().is_some() {
-            let mut ccmd = cc::Build::new();
-            ccmd.compiler(hipcc);
-            ccmd.cpp(true);
-            ccmd.include(&base_dir);
-            ccmd.flag("-include").flag("util/cuda2hip.hpp");
-            ccmd.file(&all_gpus)
-                .compile("sppark_rocm");
-            println!("cargo:rustc-cfg=feature=\"rocm\"");
+        let mut ccmd = cc::Build::new();
+        ccmd.compiler(hipcc);
+        ccmd.cpp(true);
+        ccmd.include(&base_dir);
+        ccmd.flag("-include").flag("util/cuda2hip.hpp");
+        ccmd.file(&all_gpus)
+            .compile("sppark_rocm");
+        println!("cargo:rustc-cfg=feature=\"rocm\"");
 
+        if libpath.parent().is_some() {
             println!(
                 "cargo:rustc-link-search=native={}",
                 libpath.to_string_lossy()
             );
-            println!("cargo:rustc-link-lib=amdhip64");
-            println!("cargo:TARGET=rocm");
         }
+        println!("cargo:rustc-link-lib=amdhip64");
+        println!("cargo:TARGET=rocm");
     }
 }

--- a/rust/src/cuda_available.cpp
+++ b/rust/src/cuda_available.cpp
@@ -1,0 +1,7 @@
+#include <cuda_runtime.h>
+
+int main()
+{
+    int n;
+    return cudaGetDeviceCount(&n)!=cudaSuccess || n==0;
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! cuda_error {
 }
 
 use core::ffi::c_void;
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", feature = "rocm"))]
 use core::mem::transmute;
 
 #[repr(C)]
@@ -65,7 +65,7 @@ pub struct Gpu_Ptr<T> {
     phantom: core::marker::PhantomData<T>,
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", feature = "rocm"))]
 impl<T> Default for Gpu_Ptr<T> {
     fn default() -> Self {
         Self {
@@ -75,7 +75,7 @@ impl<T> Default for Gpu_Ptr<T> {
     }
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", feature = "rocm"))]
 impl<T> Drop for Gpu_Ptr<T> {
     fn drop(&mut self) {
         extern "C" {
@@ -86,7 +86,7 @@ impl<T> Drop for Gpu_Ptr<T> {
     }
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", feature = "rocm"))]
 impl<T> Clone for Gpu_Ptr<T> {
     fn clone(&self) -> Self {
         extern "C" {

--- a/util/all_gpus.cpp
+++ b/util/all_gpus.cpp
@@ -12,11 +12,11 @@ public:
             cudaDeviceProp prop;
             if (cudaGetDeviceProperties(&prop, id) == cudaSuccess &&
                 prop.major >= 7) {
-                cudaSetDevice(id);
+                (void)cudaSetDevice(id);
                 gpus.push_back(new gpu_t(gpus.size(), id, prop));
             }
         }
-        cudaSetDevice(0);
+        (void)cudaSetDevice(0);
     }
     ~gpus_t()
     {   for (auto* ptr: gpus) delete ptr;   }

--- a/util/all_gpus.cpp
+++ b/util/all_gpus.cpp
@@ -1,5 +1,13 @@
 #include "gpu_t.cuh"
 
+#if defined(__NVCC__)
+# define PROP_MAJOR_MIN 7   // Volta and forward
+#elif defined(__HIPCC__)
+# define PROP_MAJOR_MIN 9   // CDNA/RDNA
+#else
+# error "unknown platform"
+#endif
+
 class gpus_t {
     std::vector<const gpu_t*> gpus;
 public:
@@ -11,7 +19,7 @@ public:
         for (int id = 0; id < n; id++) {
             cudaDeviceProp prop;
             if (cudaGetDeviceProperties(&prop, id) == cudaSuccess &&
-                prop.major >= 7) {
+                prop.major >= PROP_MAJOR_MIN && prop.cooperativeLaunch) {
                 (void)cudaSetDevice(id);
                 gpus.push_back(new gpu_t(gpus.size(), id, prop));
             }

--- a/util/cuda2hip.hpp
+++ b/util/cuda2hip.hpp
@@ -1,0 +1,92 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifdef __HIPCC__
+
+#include <hip/hip_runtime.h>
+
+static const auto cudaGetDeviceCount        = hipGetDeviceCount;
+static const auto cudaGetDevice             = hipGetDevice;
+static const auto cudaSetDevice             = hipSetDevice;
+static const auto cudaDeviceSynchronize     = hipDeviceSynchronize;
+
+using cudaDeviceProp                        = hipDeviceProp_t;
+static const auto cudaGetDeviceProperties   = hipGetDeviceProperties;
+static const auto cudaMemGetInfo            = hipMemGetInfo;
+
+using cudaMemcpyKind                        = hipMemcpyKind;
+static const auto cudaMemcpy                = hipMemcpy;
+static const auto cudaMemcpyAsync           = hipMemcpyAsync;
+static const auto cudaMemcpy2DAsync         = hipMemcpy2DAsync;
+#define           cudaMemcpyHostToDevice      hipMemcpyHostToDevice
+#define           cudaMemcpyDeviceToHost      hipMemcpyDeviceToHost
+#define           cudaMemcpyDeviceToDevice    hipMemcpyDeviceToDevice
+static const auto cudaMemsetAsync           = hipMemsetAsync;
+
+using cudaError_t                           = hipError_t;
+static const auto cudaGetLastError          = hipGetLastError;
+static const auto cudaGetErrorString        = hipGetErrorString;
+#define           cudaSuccess                 hipSuccess
+#define           cudaErrorNoDevice           hipErrorNoDevice
+
+using cudaEvent_t                           = hipEvent_t;
+static const auto cudaEventCreate           = hipEventCreate;
+static const auto cudaEventCreateWithFlags  = hipEventCreateWithFlags;
+#define           cudaEventDisableTiming      hipEventDisableTiming
+static const auto cudaEventRecord           = hipEventRecord;
+static const auto cudaEventDestroy          = hipEventDestroy;
+
+using cudaStream_t                          = hipStream_t;
+static const auto cudaStreamCreateWithFlags = hipStreamCreateWithFlags;
+#define           cudaStreamNonBlocking       hipStreamNonBlocking
+static const auto cudaStreamDestroy         = hipStreamDestroy;
+static const auto cudaStreamSynchronize     = hipStreamSynchronize;
+static const auto cudaStreamWaitEvent       = hipStreamWaitEvent;
+
+using cudaHostFn_t                          = hipHostFn_t;
+static const auto cudaLaunchHostFunc        = hipLaunchHostFunc;
+
+template<typename T>
+static inline cudaError_t cudaMalloc(T** devPtr, size_t size)
+{   return hipMalloc(devPtr, size);   }
+static const auto cudaFree                  = hipFree;
+
+template<typename T>
+static inline cudaError_t cudaMallocAsync(T** devPtr, size_t size,
+                                          cudaStream_t stream)
+{   return hipMallocAsync(devPtr, size, stream);   }
+static const auto cudaFreeAsync             = hipFreeAsync;
+
+template<typename T>
+static inline cudaError_t cudaGetSymbolAddress(void** devPtr, const T& symbol)
+{   return hipGetSymbolAddress(devPtr, symbol);   }
+
+template<typename T>
+static inline cudaError_t
+cudaOccupancyMaxPotentialBlockSize(int* minGridSize, int* blockSize, T func,
+                                   size_t dynamicSMemSize = 0,
+                                   int blockSizeLimit = 0)
+{   return hipOccupancyMaxPotentialBlockSize(minGridSize, blockSize, func,
+                                             dynamicSMemSize, blockSizeLimit);
+}
+
+using cudaFuncAttributes                    = hipFuncAttributes;
+
+template<typename T>
+static inline cudaError_t
+cudaFuncGetAttributes(cudaFuncAttributes* attr, T func)
+{   return hipFuncGetAttributes(attr, reinterpret_cast<const void*>(func));   }
+
+template<typename T>
+static inline cudaError_t
+cudaLaunchCooperativeKernel(const T* func, dim3 gridDim, dim3 blockDim,
+                            void** args, size_t sharedMem = 0,
+                            cudaStream_t stream = 0)
+{   return hipLaunchCooperativeKernel(func, gridDim, blockDim, args, sharedMem,
+                                      stream);
+}
+
+static inline __device__ void __syncwarp() { asm volatile(""); }
+
+#endif

--- a/util/cuda2hip.hpp
+++ b/util/cuda2hip.hpp
@@ -5,6 +5,11 @@
 #ifdef __HIPCC__
 
 #include <hip/hip_runtime.h>
+#ifdef NDEBUG
+# define assert(e) (void)(e)
+#else
+# include <cassert>
+#endif
 
 static const auto cudaGetDeviceCount        = hipGetDeviceCount;
 static const auto cudaGetDevice             = hipGetDevice;
@@ -89,4 +94,160 @@ cudaLaunchCooperativeKernel(const T* func, dim3 gridDim, dim3 blockDim,
 
 static inline __device__ void __syncwarp() { asm volatile(""); }
 
+/*
+ * To match CUDA, the 3-argument polyfills below are designed to produce
+ * a result as if the wavefront size is 32 irregardless of its actual size.
+ * They don't follow the CUDA semantics exactly and rely on indices to be
+ * properly vetted by the caller, all in the name of minimizing the amount
+ * of instructions. If in doubt, add WARP_SZ as the fourth argument to opt
+ * for the more expensive ROCm primitives.
+ *
+ * A note about 'assert(mask == 0xffffffff);'. The mask is customarily
+ * passed as a literal, in which case the assertion is bound to be
+ * optimized away.
+ */
+
+#define WARP_SZ 32
+
+template<typename T> __device__ __forceinline__
+static T __shfl_sync(uint32_t mask, const T& src, uint32_t idx)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    idx += threadIdx.x & (0-WARP_SZ);
+    idx *= sizeof(uint32_t);
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __builtin_amdgcn_ds_bpermute(idx, ret.vec[i]);
+
+    return ret.val;
+}
+
+template<typename T> __device__ __forceinline__
+static T __shfl_sync(uint32_t mask, const T& src, uint32_t idx, uint32_t warpsz)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __shfl(ret.vec[i], idx, warpsz);
+
+    return ret.val;
+}
+
+template<typename T> __device__ __forceinline__
+static T __shfl_up_sync(uint32_t mask, const T& src, uint32_t off)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    uint32_t idx = threadIdx.x - off;
+    idx *= sizeof(uint32_t);
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __builtin_amdgcn_ds_bpermute(idx, ret.vec[i]);
+
+    return ret.val;
+}
+
+template<typename T> __device__ __forceinline__
+static T __shfl_up_sync(uint32_t mask, const T& src, uint32_t off, uint32_t warpsz)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __shfl_up(ret.vec[i], off, warpsz);
+
+    return ret.val;
+}
+
+template<typename T> __device__ __forceinline__
+static T __shfl_down_sync(uint32_t mask, const T& src, uint32_t off)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    uint32_t idx = threadIdx.x + off;
+    idx *= sizeof(uint32_t);
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __builtin_amdgcn_ds_bpermute(idx, ret.vec[i]);
+
+    return ret.val;
+}
+
+template<typename T> __device__ __forceinline__
+static T __shfl_down_sync(uint32_t mask, const T& src, uint32_t off, uint32_t warpsz)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __shfl_down(ret.vec[i], off, warpsz);
+
+    return ret.val;
+}
+
+template<typename T> __device__ __forceinline__
+static T __shfl_xor_sync(uint32_t mask, const T& src, uint32_t laneMask)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    uint32_t idx = threadIdx.x ^ laneMask;
+    idx *= sizeof(uint32_t);
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __builtin_amdgcn_ds_bpermute(idx, ret.vec[i]);
+
+    return ret.val;
+}
+
+template<typename T> __device__ __forceinline__
+static T __shfl_xor_sync(uint32_t mask, const T& src, uint32_t laneMask, uint32_t warpsz)
+{
+    assert(mask == 0xffffffff);
+
+    const size_t len = sizeof(T)/sizeof(uint32_t);
+    union { T val; uint32_t vec[len]; } ret{src};
+
+    for (size_t i = 0; i < len; i++)
+        ret.vec[i] = __shfl_xor(ret.vec[i], laneMask, warpsz);
+
+    return ret.val;
+}
+
+/*
+ * Mimic CUDA __ballot_sync by "splitting" wider wavefronts to halves.
+ */
+__device__ __forceinline__
+static uint32_t __ballot_sync(uint32_t mask, bool predicate)
+{
+    assert(mask == 0xffffffff);
+
+    uint64_t ret = __ballot(predicate);
+
+    if (__AMDGCN_WAVEFRONT_SIZE == 64) {
+        return (uint32_t)((threadIdx.x & WARP_SZ) ? ret>>32 : ret);
+    } else {
+        asm("" : "+v"(ret)); /* work around[?] a compiler bug */
+        return (uint32_t)ret;
+    }
+}
+
+#ifdef NDEBUG
+# undef assert
+#endif
 #endif

--- a/util/gpu_t.cuh
+++ b/util/gpu_t.cuh
@@ -347,7 +347,7 @@ public:
     inline T& operator[](size_t i)              { return d_ptr[i]; }
 };
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__HIP_DEVICE_COMPILE__)
 # define SPPARK_FFI extern "C" __declspec(dllexport)
 #else
 # define SPPARK_FFI extern "C" __attribute__((visibility("default")))

--- a/util/rusterror.h
+++ b/util/rusterror.h
@@ -11,6 +11,9 @@
 #else
 # include <string.h>
 #endif
+#ifdef _MSC_VER
+# define strdup _strdup
+#endif
 
 struct RustError { /* to be returned exclusively by value */
     int code;
@@ -31,6 +34,9 @@ struct RustError { /* to be returned exclusively by value */
     operator by_value() const { return {code, message}; }
 #endif
 };
+#ifdef _MSC_VER
+# undef strdup
+#endif
 #ifndef __cplusplus
 typedef struct RustError RustError;
 #endif

--- a/util/slice_t.hpp
+++ b/util/slice_t.hpp
@@ -7,7 +7,7 @@
 
 #include <vector>
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 # ifdef inline
 #  define slice_t_saved_inline inline
 #  undef inline
@@ -33,7 +33,7 @@ public:
     inline const T& operator[](size_t i) const  { return ptr[i]; }
 };
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 # undef inline
 # ifdef slice_t_saved_inline
 #  define inline slice_t_saved_inline

--- a/util/vec2d_t.hpp
+++ b/util/vec2d_t.hpp
@@ -7,7 +7,7 @@
 
 #include <cstdint>
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 # define __host__
 # define __device__
 #endif
@@ -23,7 +23,7 @@ public:
     vec2d_t(void* data, dim_t x)  : dim_x(x), owned(false), ptr((T*)data) {}
     vec2d_t(dim_t x, size_t y) : dim_x(x), owned(true),  ptr(new T[x*y]) {}
     vec2d_t() : dim_x(0), owned(false), ptr(nullptr) {}
-#ifndef __CUDA_ARCH__
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
     vec2d_t(const vec2d_t& other) { *this = other; owned = false; }
     ~vec2d_t() { if (owned) delete[] ptr; }
 
@@ -48,7 +48,7 @@ public:
 #endif
 };
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 # undef __device__
 # undef __host__
 #endif


### PR DESCRIPTION
When system libraries are configured correctly, it doesn't matter whether script can find the library path this way, `cargo:rustc-link-lib` isn't necessary in that case either.

I'm not sure how this works (or not) on Windows yet, but on Linux it works without those instructions if following official AMD installation instructions. Because of this I left the logic in place, but allow hipcc to attempt compilation regardless of whether dynamic libraries were found or not.

This is necessary for compiling with hipcc 5.7.1 as shipped in Ubuntu 24.04 stock repos.